### PR TITLE
Name shadowing and return statements without expressions

### DIFF
--- a/src/lexer/lexer.l
+++ b/src/lexer/lexer.l
@@ -17,6 +17,8 @@
 type bool|i8|u8|i16|u16|i32|u32|i64|u64|isize|usize|f32|f64|char|auto|str
 identifier [A-Za-z_]+[0-9]*
 character ['][^'.][']
+/* a string but with single quotes (to handle errors) */
+invalid_character ['][^".]*[']
 integer_literal [0-9]+
 float_literal [0-9]*\.[0-9]+
 string ["][^".]*["]
@@ -72,7 +74,10 @@ or or|[|][|]
 {multi_line_comment} {}
 {one_line_comment} {}
 [ \t\r\n] {}
-. {syntax::nonfatal_error(std::chrono::high_resolution_clock::now(), "Unrecognized token", "The following characters could not be defined as a token: ", yytext);}
+{invalid_character} {syntax::nonfatal_error(std::chrono::high_resolution_clock::now(), "Invalid character literal", "A character literal was found on line " + std::to_string(yylineno) + " with more then one character in it");}
+"\"" {syntax::nonfatal_error(std::chrono::high_resolution_clock::now(), "Unmatched double quote", "An unmatched double quote was found on line " + std::to_string(yylineno));}
+"'" {syntax::nonfatal_error(std::chrono::high_resolution_clock::now(), "Unmatched single quote", "An unmatched single quote was found on line " + std::to_string(yylineno));}
+. {syntax::nonfatal_error(std::chrono::high_resolution_clock::now(), "Unrecognized token", "The following characters could not be defined as a token at line " + std::to_string(yylineno) + ": ", yytext);}
 %%
 
 // flex uses this when it encounters end of file, to check if it should continue to another file

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -130,6 +130,7 @@ forLoop
 
 returnStatement
     : TOK_RETURN expression {$$ = new ASTReturnStatement($2);}
+    | TOK_RETURN {$$ = new ASTReturnStatement();}
     ;
 
 parameterList

--- a/src/parser/wrappers.h
+++ b/src/parser/wrappers.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <string>
+#include <regex>
 #include "ast.h"
 
 // create a wrapper struct around the std::vector, so that it can be used in the bison union
@@ -27,16 +28,28 @@ struct VectorWrapper {
     inline std::vector<ASTNode*> &getVector() const { return *vector; }
 };
 
+static std::string *replaceEscape(const std::string& string) {
+    // replace all "\\n" with "\n"
+    std::string modifiedString = std::regex_replace(string, std::regex("\\\\n"), "\n");
+    // replace all "\\t" with "\t"
+    modifiedString = std::regex_replace(modifiedString, std::regex("\\\\t"), "\t");
+    return new std::string(std::move(modifiedString));
+}
+
 // create a wrapper struct around the std::string, so that it can be used in the bison union
 struct StringWrapper {
     std::string *string;
     // create a std::string from s and store it in string
     explicit StringWrapper(char *s) {
-        string = new std::string(s);
+        std::string str(s);
+        // to replace \\n, \\t and so on with just one \ so it works correctly
+        string = replaceEscape(str);
     }
     // create a std::string from s and length and store it in string
     explicit StringWrapper(char *s, int length) {
-        string = new std::string(s, length);
+        std::string str(s, length);
+        // to replace \\n, \\t and so on with just one \ so it works correctly
+        string = replaceEscape(str);
     }
     ~StringWrapper() {
         delete string;

--- a/tests/code.lts
+++ b/tests/code.lts
@@ -1,3 +1,18 @@
-fn main() {
-    ret;
+fn main() -> i32 {
+    x: i32 = 10;
+    {
+        x: i32 = 50;
+        {
+            x: i32 = 100;
+            printf("x is %d\n", x);
+        }
+        printf("x is %d\n", x);
+    }
+    printf("x is %d", x);
+    ret 0;
 }
+/* prints
+x is 100
+x is 50
+x is 10
+*/

--- a/tests/code.lts
+++ b/tests/code.lts
@@ -1,7 +1,3 @@
-fn main() -> i32 {
-    for i := 0; i < 10; i++ {
-        if i > 0: printf(", ");
-        printf("%d", i);
-    }
-    ret 42;
+fn main() {
+    ret;
 }


### PR DESCRIPTION
Added a scope stack to keep track of different variable names in different scopes, which is turn enables support for name shadowing where multiple variables in different scopes can share the same name. Also added return statements without expressions and more errors if functions that don't have a return type are called in expressions. Also fixed an issue where \n was not handled correctly.