### PR TITLE
Break and continue statements and more operators

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,5 @@
 name: C/C++ CI for Lotus Compiler
 
-# test change here!
-
 on:
   push:
     branches: [main, dev]
@@ -16,15 +14,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install CMake and Ninja TEST
+      - name: Install CMake and Ninja
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build
 
-      - name: Generate build system TEST
+      - name: Generate build system
         run: cmake -G "Ninja" -S . -B build
 
-      - name: Build project TEST
+      - name: Build project
         run: cmake --build build --config Release
 
       - name: Verify executable

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,7 @@
 name: C/C++ CI for Lotus Compiler
 
+# test change here!
+
 on:
   push:
     branches: [main, dev]
@@ -14,15 +16,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install CMake and Ninja
+      - name: Install CMake and Ninja TEST
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build
 
-      - name: Generate build system
+      - name: Generate build system TEST
         run: cmake -G "Ninja" -S . -B build
 
-      - name: Build project
+      - name: Build project TEST
         run: cmake --build build --config Release
 
       - name: Verify executable

--- a/src/lexer/lexer.l
+++ b/src/lexer/lexer.l
@@ -46,6 +46,8 @@ or or|[|][|]
 "while" {return TOK_WHILE;}
 "for" {return TOK_FOR;}
 "fn" {return TOK_FN;}
+"continue" {return TOK_CONTINUE;}
+"break" {return TOK_BREAK;}
 "true" {return TOK_TRUE;}
 "false" {return TOK_FALSE;}
 {not} {return TOK_NOT;}

--- a/src/lexer/lexer.l
+++ b/src/lexer/lexer.l
@@ -65,6 +65,9 @@ or or|[|][|]
 "--" {return TOK_DECREMENT;}
 "+=" {return TOK_PLUS_EQUALS;}
 "-=" {return TOK_HYPHEN_EQUALS;}
+"*=" {return TOK_ASTERISK_EQUALS;}
+"/=" {return TOK_F_SLASH_EQUALS;}
+"%=" {return TOK_PERCENT_EQUALS;}
 "+" {return TOK_PLUS;}
 "-" {return TOK_HYPHEN;}
 "*" {return TOK_ASTERISK;}

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -53,7 +53,7 @@ static llvm::Type *getLLVMType(const std::string& type, const std::unique_ptr<ll
     } else if (type == "char") {
         return builder->getInt8Ty();
     } else if (type == "str") {
-        return builder->getPtrTy();
+        return llvm::PointerType::get(builder->getInt8Ty(), 0);
     } else {
         // return a void type
         return builder->getVoidTy();

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -33,7 +33,7 @@ std::unique_ptr<AST> ast;
 %token<float_literal> TOK_FLOAT_LITERAL
 %token<str> TOK_IDENTIFIER TOK_TYPE TOK_STR_LITERAL TOK_F_STR_START TOK_F_STR_MIDDLE TOK_F_STR_END
 %token<character> TOK_CHAR_LITERAL
-%token TOK_LET TOK_EQUALS TOK_SEMICOLON TOK_PLUS TOK_HYPHEN TOK_ASTERISK TOK_F_SLASH TOK_L_PAREN TOK_R_PAREN TOK_L_BRACE TOK_R_BRACE TOK_RETURN TOK_IF TOK_ELSE TOK_WHILE TOK_FOR TOK_FN TOK_COMMA TOK_ARROW TOK_COLON TOK_DOT TOK_DOUBLE_EQUALS TOK_LESS_THAN TOK_GREATER_THAN TOK_LESS_THAN_EQUALS TOK_GREATER_THAN_EQUALS TOK_NOT_EQUALS TOK_TRUE TOK_FALSE TOK_NOT TOK_AND TOK_OR TOK_TILDA TOK_AS TOK_INCREMENT TOK_DECREMENT TOK_PERCENT TOK_PLUS_EQUALS TOK_HYPHEN_EQUALS
+%token TOK_LET TOK_EQUALS TOK_SEMICOLON TOK_PLUS TOK_HYPHEN TOK_ASTERISK TOK_F_SLASH TOK_L_PAREN TOK_R_PAREN TOK_L_BRACE TOK_R_BRACE TOK_RETURN TOK_IF TOK_ELSE TOK_WHILE TOK_FOR TOK_FN TOK_COMMA TOK_ARROW TOK_COLON TOK_DOT TOK_DOUBLE_EQUALS TOK_LESS_THAN TOK_GREATER_THAN TOK_LESS_THAN_EQUALS TOK_GREATER_THAN_EQUALS TOK_NOT_EQUALS TOK_TRUE TOK_FALSE TOK_NOT TOK_AND TOK_OR TOK_TILDA TOK_AS TOK_INCREMENT TOK_DECREMENT TOK_PERCENT TOK_PLUS_EQUALS TOK_HYPHEN_EQUALS TOK_PERCENT_EQUALS TOK_ASTERISK_EQUALS TOK_F_SLASH_EQUALS
 
 %type<node> expression instanceStatement localStatement compoundStatement functionDefinition functionPrototype parameter returnStatement functionCall arithmeticExpression term factor closedStatement openStatement booleanExpression booleanExpression2 booleanExpression3 variableDeclaration variableAssignment variableDefinition ifCompatibleStatement whileLoop forLoop factor2
 %type<nodeList> instanceStatementList localStatementList parameterList argumentList
@@ -102,7 +102,12 @@ variableDeclaration
     ;
 
 variableAssignment
-    : TOK_IDENTIFIER TOK_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3); delete $1;}
+    : TOK_IDENTIFIER TOK_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3, ""); delete $1;}
+    | TOK_IDENTIFIER TOK_PLUS_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3, "+"); delete $1;}
+    | TOK_IDENTIFIER TOK_HYPHEN_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3, "-"); delete $1;}
+    | TOK_IDENTIFIER TOK_ASTERISK_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3, "*"); delete $1;}
+    | TOK_IDENTIFIER TOK_F_SLASH_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3, "/"); delete $1;}
+    | TOK_IDENTIFIER TOK_PERCENT_EQUALS expression {$$ = new ASTVariableAssignment($1->getString(), $3, "%"); delete $1;}
     ;
 
 variableDefinition

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -33,7 +33,7 @@ std::unique_ptr<AST> ast;
 %token<float_literal> TOK_FLOAT_LITERAL
 %token<str> TOK_IDENTIFIER TOK_TYPE TOK_STR_LITERAL TOK_F_STR_START TOK_F_STR_MIDDLE TOK_F_STR_END
 %token<character> TOK_CHAR_LITERAL
-%token TOK_LET TOK_EQUALS TOK_SEMICOLON TOK_PLUS TOK_HYPHEN TOK_ASTERISK TOK_F_SLASH TOK_L_PAREN TOK_R_PAREN TOK_L_BRACE TOK_R_BRACE TOK_RETURN TOK_IF TOK_ELSE TOK_WHILE TOK_FOR TOK_FN TOK_COMMA TOK_ARROW TOK_COLON TOK_DOT TOK_DOUBLE_EQUALS TOK_LESS_THAN TOK_GREATER_THAN TOK_LESS_THAN_EQUALS TOK_GREATER_THAN_EQUALS TOK_NOT_EQUALS TOK_TRUE TOK_FALSE TOK_NOT TOK_AND TOK_OR TOK_TILDA TOK_AS TOK_INCREMENT TOK_DECREMENT TOK_PERCENT TOK_PLUS_EQUALS TOK_HYPHEN_EQUALS TOK_PERCENT_EQUALS TOK_ASTERISK_EQUALS TOK_F_SLASH_EQUALS
+%token TOK_LET TOK_EQUALS TOK_SEMICOLON TOK_PLUS TOK_HYPHEN TOK_ASTERISK TOK_F_SLASH TOK_L_PAREN TOK_R_PAREN TOK_L_BRACE TOK_R_BRACE TOK_RETURN TOK_IF TOK_ELSE TOK_WHILE TOK_FOR TOK_FN TOK_COMMA TOK_ARROW TOK_COLON TOK_DOT TOK_DOUBLE_EQUALS TOK_LESS_THAN TOK_GREATER_THAN TOK_LESS_THAN_EQUALS TOK_GREATER_THAN_EQUALS TOK_NOT_EQUALS TOK_TRUE TOK_FALSE TOK_NOT TOK_AND TOK_OR TOK_TILDA TOK_AS TOK_INCREMENT TOK_DECREMENT TOK_PERCENT TOK_PLUS_EQUALS TOK_HYPHEN_EQUALS TOK_PERCENT_EQUALS TOK_ASTERISK_EQUALS TOK_F_SLASH_EQUALS TOK_BREAK TOK_CONTINUE
 
 %type<node> expression instanceStatement localStatement compoundStatement functionDefinition functionPrototype parameter returnStatement functionCall arithmeticExpression term factor closedStatement openStatement booleanExpression booleanExpression2 booleanExpression3 variableDeclaration variableAssignment variableDefinition ifCompatibleStatement whileLoop forLoop factor2
 %type<nodeList> instanceStatementList localStatementList parameterList argumentList
@@ -81,6 +81,8 @@ closedStatement
     | whileLoop {$$ = $1;}
     | forLoop {$$ = $1;}
     | compoundStatement {$$ = $1;}
+    | TOK_CONTINUE TOK_SEMICOLON {$$ = new ASTContinueStatement();}
+    | TOK_BREAK TOK_SEMICOLON {$$ = new ASTBreakStatement();}
     ;
 
 /* this defines statements that are open, meaning they can be the start of a bigger statement or not */

--- a/tests/code.lts
+++ b/tests/code.lts
@@ -1,36 +1,7 @@
 fn main() {
-    // Test casting integer to boolean
-    a: bool = 1;
-    b: bool = 0;
-    printf("i32 to bool: 1 -> %d, 0 -> %d\n", a~i32, b~i32);
-
-    // Test casting float to boolean
-    c: bool = 234.234;
-    d: bool = 0.0;
-    printf("f64 to bool: 234.234 -> %d, 0.0 -> %d\n", c~i32, d~i32);
-
-    // Test casting boolean to integer
-    e: i32 = true;
-    f: i32 = false;
-    printf("bool to i32: true -> %d, false -> %d\n", e, f);
-
-    // Test casting boolean to float
-    g: f64 = true;
-    h: f64 = false;
-    printf("bool to f64: true -> %f, false -> %f\n", g, h);
-
-    // Test casting integer to float
-    i: f64 = 42;
-    printf("i32 to f64: 42 -> %f\n", i);
-
-    // Test casting float to integer
-    j: i32 = 42.99;
-    k: i32 = -42.99;
-    printf("f64 to i32: 42.99 -> %d, -42.99 -> %d\n", j, k);
-
-    // Additional edge cases
-    l: bool = -1; // Non-zero integer to boolean
-    m: bool = 0.0001; // Small non-zero float to boolean
-    n: bool = -0.0001; // Small negative non-zero float to boolean
-    printf("Edge cases: -1 -> %d, 0.0001 -> %d, -0.0001 -> %d\n", l~i32, m~i32, n~i32);
+    x := 10;
+    x += 5;
+    y := x--;
+    y %= x;
+    printf("%d, %d", x, y);
 }

--- a/tests/code.lts
+++ b/tests/code.lts
@@ -1,7 +1,44 @@
 fn main() {
-    x := 10;
-    x += 5;
-    y := x--;
-    y %= x;
-    printf("%d, %d", x, y);
+    i: i32 = 0;
+    while i < 5 {
+        for j := 0; j < 5; j++ {
+            if j == 3 {
+                printf("continue, i: %d, j: %d\n", i, j);
+                continue;  // Skip the rest of the inner loop when j is 3
+            }
+            if i == 2 && j == 4 {
+                printf("break, i: %d, j: %d\n", i, j);
+                break;  // Break the inner loop when i is 2 and j is 4
+            }
+            printf("i: %d, j: %d\n", i, j);
+        }
+        i += 1;
+    }
+
+    // Output:
+    // i: 0, j: 0
+    // i: 0, j: 1
+    // i: 0, j: 2
+    // continue, i: 0, j: 3
+    // i: 0, j: 4
+    // i: 1, j: 0
+    // i: 1, j: 1
+    // i: 1, j: 2
+    // continue, i: 1, j: 3
+    // i: 1, j: 4
+    // i: 2, j: 0
+    // i: 2, j: 1
+    // i: 2, j: 2
+    // continue, i: 2, j: 3
+    // break, i: 2, j: 4
+    // i: 3, j: 0
+    // i: 3, j: 1
+    // i: 3, j: 2
+    // continue, i: 3, j: 3
+    // i: 3, j: 4
+    // i: 4, j: 0
+    // i: 4, j: 1
+    // i: 4, j: 2
+    // continue, i: 4, j: 3
+    // i: 4, j: 4
 }


### PR DESCRIPTION
Implemented break and continue statements inside of for and while loops.
Added the following assignment operators:
- +=
- -=
- *=
- /=
- %=

Added support for using operands of different types with boolean operators like for example:
```
x := 4;
42 && x > 3 // true
y := false;
11.3 || y // true
```
All integers and floating points are casted to boolean before the boolean operation is performed.