### PR TITLE
Stack allocated arrays and array literals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(Lotus src/main.cpp
         ${BISON_Parser_OUTPUTS}
         ${FLEX_Lexer_OUTPUTS}
         src/generator/typeSystem.h
+        src/generator/casting.h
 )
 
 # Ensures that llvm links against the correct libraries

--- a/src/generator/casting.h
+++ b/src/generator/casting.h
@@ -1,0 +1,224 @@
+// Copyright 2024 Lucas Norman
+
+#pragma once
+
+#include <map>
+#include <ranges>
+#include <regex>
+#include <vector>
+
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+
+#include "scopeStack.h"
+#include "typeSystem.h"
+
+
+#include "../diagnostics/generator.h"
+
+namespace casting {
+
+// helper function to create a llvm cast instruction
+static llvm::Value*
+createCast(llvm::Value* value, const typeSystem::Type& sourceType,
+           const typeSystem::Type& destinationType,
+           const std::unique_ptr<llvm::IRBuilder<>>& builder,
+           // an optional pointer to the value (used when casting arrays)
+           llvm::Value* pointer = nullptr) {
+    if (sourceType == destinationType) {
+        // no cast needed
+        return value;
+    }
+
+    llvm::Type* llvmDestinationType = destinationType.toLLVMType(builder);
+
+    // if the source type is bool
+    if (sourceType.isBooleanType()) {
+        if (destinationType.isIntegerType()) {
+            return builder->CreateCast(llvm::Instruction::ZExt, value,
+                                       llvmDestinationType, "tmpcast");
+        } else if (destinationType.isFloatingPointType()) {
+            return builder->CreateCast(llvm::Instruction::UIToFP, value,
+                                       llvmDestinationType, "tmpcast");
+        }
+    }
+
+    // if the destination type is bool, then check if the value does not equal 0
+    if (destinationType.isBooleanType()) {
+        if (sourceType.isIntegerType()) {
+            return builder->CreateICmpNE(
+                value, llvm::ConstantInt::get(value->getType(), 0),
+                "cmptozero");
+        } else if (sourceType.isFloatingPointType()) {
+            return builder->CreateFCmpONE(
+                value, llvm::ConstantFP::get(value->getType(), 0), "cmptozero");
+        }
+    }
+
+    // if the source type and destination type is an integer or floating point
+    if ((sourceType.isIntegerType() || sourceType.isFloatingPointType()) &&
+        (destinationType.isIntegerType() ||
+         destinationType.isFloatingPointType())) {
+        llvm::CastInst::CastOps castOperation = llvm::CastInst::getCastOpcode(
+            value, true, llvmDestinationType, true);
+        return builder->CreateCast(castOperation, value, llvmDestinationType,
+                                   "tmpcast");
+    }
+
+    // throw error, cast is not supported
+    generator::fatal_error(std::chrono::high_resolution_clock::now(),
+                           "Invalid cast",
+                           "Cannot cast from '" + sourceType.toString() +
+                               "' to '" + destinationType.toString() + "'");
+    return nullptr;
+}
+
+// helper function for getting the boolean representation of a llvm::Value*
+static llvm::Value*
+toBoolean(llvm::Value* value, const typeSystem::Type& sourceType,
+          const std::unique_ptr<llvm::IRBuilder<>>& builder) {
+    return createCast(value, sourceType, typeSystem::Type{"bool"}, builder);
+}
+
+// helper function to create binary operations
+static std::tuple<llvm::Value*, typeSystem::Type>
+createBinaryOperation(llvm::Value* leftValue, llvm::Value* rightValue,
+                      const typeSystem::Type& leftType,
+                      const typeSystem::Type& rightType,
+                      const std::string& operation,
+                      const std::unique_ptr<llvm::IRBuilder<>>& builder) {
+    // these can be performed with different types because both sides are cast
+    // to booleans
+    if (operation == "&&") {
+        return {builder->CreateAnd(toBoolean(leftValue, leftType, builder),
+                                   toBoolean(rightValue, rightType, builder),
+                                   "andtmp"),
+                typeSystem::Type{"bool"}};
+    } else if (operation == "||") {
+        return {builder->CreateOr(toBoolean(leftValue, leftType, builder),
+                                  toBoolean(rightValue, rightType, builder),
+                                  "ortmp"),
+                typeSystem::Type{"bool"}};
+    }
+
+    // check if the left and right expression have the same type
+    if (leftType != rightType) {
+        generator::fatal_error(std::chrono::high_resolution_clock::now(),
+                               "Type mismatch in binary operation",
+                               "Cannot perform the binary operation '" +
+                                   operation + "' with the types '" +
+                                   leftType.toString() + "' and '" +
+                                   rightType.toString() + "'");
+        return {};
+    }
+
+    bool isFloatingPointOperation = leftType.isFloatingPointType();
+    // if it is an integer that is not an i1 (boolean)
+    bool isIntegerOperation = leftType.isIntegerType();
+
+    llvm::Value* resultValue = nullptr;
+
+    // these operations can only be performed if the types are the same
+    if (operation == "+") {
+        if (isFloatingPointOperation) {
+            resultValue =
+                builder->CreateFAdd(leftValue, rightValue, "addfloattmp");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateAdd(leftValue, rightValue, "addtmp");
+        }
+    } else if (operation == "-") {
+        if (isFloatingPointOperation) {
+            resultValue =
+                builder->CreateFSub(leftValue, rightValue, "subfloattmp");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateSub(leftValue, rightValue, "subtmp");
+        }
+    } else if (operation == "*") {
+        if (isFloatingPointOperation) {
+            resultValue =
+                builder->CreateFMul(leftValue, rightValue, "mulfloattmp");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateMul(leftValue, rightValue, "multmp");
+        }
+    } else if (operation == "/") {
+        if (isFloatingPointOperation) {
+            resultValue =
+                builder->CreateFDiv(leftValue, rightValue, "divfloattmp");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateSDiv(leftValue, rightValue, "divtmp");
+        }
+    } else if (operation == "%") {
+        if (isFloatingPointOperation) {
+            resultValue =
+                builder->CreateFRem(leftValue, rightValue, "remfloattmp");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateSRem(leftValue, rightValue, "remtmp");
+        }
+    } else if (operation == "==") {
+        if (isFloatingPointOperation) {
+            resultValue = builder->CreateFCmpOEQ(leftValue, rightValue,
+                                                 "cmpfloattmpequals");
+        } else if (isIntegerOperation) {
+            resultValue =
+                builder->CreateICmpEQ(leftValue, rightValue, "cmptmpequals");
+        }
+    } else if (operation == "!=") {
+        if (isFloatingPointOperation) {
+            resultValue = builder->CreateFCmpONE(leftValue, rightValue,
+                                                 "cmpfloattmpnotequals");
+        } else if (isIntegerOperation) {
+            resultValue =
+                builder->CreateICmpNE(leftValue, rightValue, "cmptmpnotequals");
+        }
+    } else if (operation == "<") {
+        if (isFloatingPointOperation) {
+            resultValue = builder->CreateFCmpOLT(leftValue, rightValue,
+                                                 "cmpfloattmpless");
+        } else if (isIntegerOperation) {
+            resultValue =
+                builder->CreateICmpSLT(leftValue, rightValue, "cmptmpless");
+        }
+    } else if (operation == ">") {
+        if (isFloatingPointOperation) {
+            resultValue = builder->CreateFCmpOGT(leftValue, rightValue,
+                                                 "cmpfloattmpgreater");
+        } else if (isIntegerOperation) {
+            resultValue =
+                builder->CreateICmpSGT(leftValue, rightValue, "cmptmpgreater");
+        }
+    } else if (operation == "<=") {
+        if (isFloatingPointOperation) {
+            resultValue = builder->CreateFCmpOLE(leftValue, rightValue,
+                                                 "cmpfloattmplessequals");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateICmpSLE(leftValue, rightValue,
+                                                 "cmptmplessequals");
+        }
+    } else if (operation == ">=") {
+        if (isFloatingPointOperation) {
+            resultValue = builder->CreateFCmpOGE(leftValue, rightValue,
+                                                 "cmpfloattmpgreaterequals");
+        } else if (isIntegerOperation) {
+            resultValue = builder->CreateICmpSGE(leftValue, rightValue,
+                                                 "cmptmpgreaterequals");
+        }
+    }
+
+    // if no operators matched, then throw an error
+    if (resultValue == nullptr) {
+        generator::fatal_error(std::chrono::high_resolution_clock::now(),
+                               "Invalid binary operator",
+                               "The binary operator '" + operation +
+                                   "' is not supported with the type '" +
+                                   leftType.toString() + "'");
+        return {};
+    }
+    // return the result value together with the resulting type (the leftType
+    // and rightType are the same here)
+    return {resultValue, leftType};
+}
+}  // namespace casting

--- a/src/lexer/lexer.l
+++ b/src/lexer/lexer.l
@@ -10,7 +10,7 @@
 
 #include "../diagnostics/lexer.h"
 
-uint64_t parseInt(const char *str) {
+uint64_t parseInt(const char* str) {
     try {
         return std::stoull(str);
     } catch (const std::out_of_range& e) {
@@ -23,7 +23,7 @@ uint64_t parseInt(const char *str) {
 %option yylineno
 
 /* Regex */
-type (?:\*|\*mut[ ])*(?:bool|i8|u8|i16|u16|i32|u32|i64|u64|isize|usize|f32|f64|char|str)|auto
+type (?:\*|\*mut[ ])*\[*(?:\*|\*mut[ ])*(?:bool|i8|u8|i16|u16|i32|u32|i64|u64|isize|usize|f32|f64|char|str)(?:\|[0-9]+\])*|auto
 identifier [A-Za-z_]+[0-9]*
 character '[^']'
 /* a string but with single quotes (to handle errors) */
@@ -71,6 +71,7 @@ or or|\|\|
 "*=" {return TOK_ASTERISK_EQUALS;}
 "/=" {return TOK_F_SLASH_EQUALS;}
 "%=" {return TOK_PERCENT_EQUALS;}
+":=" {return TOK_WALRUS;}
 "+" {return TOK_PLUS;}
 "-" {return TOK_HYPHEN;}
 "*" {return TOK_ASTERISK;}
@@ -80,6 +81,8 @@ or or|\|\|
 ")" {return TOK_R_PAREN;}
 "{" {return TOK_L_BRACE;}
 "}" {return TOK_R_BRACE;}
+"[" {return TOK_L_BRACKET;}
+"]" {return TOK_R_BRACKET;}
 ";" {return TOK_SEMICOLON;}
 ":" {return TOK_COLON;}
 "," {return TOK_COMMA;}

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -13,9 +13,9 @@
 
 extern int yylex();
 extern int yyparse();
-extern FILE *yyin;
+extern FILE* yyin;
 extern int yylineno;
-void yyerror(const char *s);
+void yyerror(const char* s);
 std::unique_ptr<AST> ast;
 %}
 
@@ -24,20 +24,20 @@ std::unique_ptr<AST> ast;
 %union {
     uint64_t int_literal;
     double float_literal;
-    struct StringWrapper *str;
+    struct StringWrapper* str;
     char character;
-    struct VectorWrapper *nodeList;
-    class ASTNode *node;
+    struct VectorWrapper* nodeList;
+    class ASTNode* node;
 }
 
 %token<int_literal> TOK_INT_LITERAL
 %token<float_literal> TOK_FLOAT_LITERAL
 %token<str> TOK_IDENTIFIER TOK_TYPE TOK_STR_LITERAL
 %token<character> TOK_CHAR_LITERAL
-%token TOK_EQUALS TOK_SEMICOLON TOK_PLUS TOK_HYPHEN TOK_ASTERISK TOK_F_SLASH TOK_L_PAREN TOK_R_PAREN TOK_L_BRACE TOK_R_BRACE TOK_RETURN TOK_IF TOK_ELSE TOK_WHILE TOK_FOR TOK_FN TOK_COMMA TOK_ARROW TOK_COLON TOK_DOUBLE_EQUALS TOK_LESS_THAN TOK_GREATER_THAN TOK_LESS_THAN_EQUALS TOK_GREATER_THAN_EQUALS TOK_NOT_EQUALS TOK_TRUE TOK_FALSE TOK_NOT TOK_AND TOK_OR TOK_TILDA TOK_AS TOK_INCREMENT TOK_DECREMENT TOK_PERCENT TOK_PLUS_EQUALS TOK_HYPHEN_EQUALS TOK_PERCENT_EQUALS TOK_ASTERISK_EQUALS TOK_F_SLASH_EQUALS TOK_BREAK TOK_CONTINUE TOK_AMPERSAND TOK_MUT
+%token TOK_EQUALS TOK_WALRUS TOK_SEMICOLON TOK_PLUS TOK_HYPHEN TOK_ASTERISK TOK_F_SLASH TOK_L_PAREN TOK_R_PAREN TOK_L_BRACE TOK_R_BRACE TOK_L_BRACKET TOK_R_BRACKET TOK_RETURN TOK_IF TOK_ELSE TOK_WHILE TOK_FOR TOK_FN TOK_COMMA TOK_ARROW TOK_COLON TOK_DOUBLE_EQUALS TOK_LESS_THAN TOK_GREATER_THAN TOK_LESS_THAN_EQUALS TOK_GREATER_THAN_EQUALS TOK_NOT_EQUALS TOK_TRUE TOK_FALSE TOK_NOT TOK_AND TOK_OR TOK_TILDA TOK_AS TOK_INCREMENT TOK_DECREMENT TOK_PERCENT TOK_PLUS_EQUALS TOK_HYPHEN_EQUALS TOK_PERCENT_EQUALS TOK_ASTERISK_EQUALS TOK_F_SLASH_EQUALS TOK_BREAK TOK_CONTINUE TOK_AMPERSAND TOK_MUT
 
-%type<node> expression instanceStatement localStatement compoundStatement functionDefinition functionPrototype parameter returnStatement functionCall arithmeticExpression term factor closedStatement openStatement booleanExpression booleanExpression2 booleanExpression3 variableDeclaration variableAssignment variableDefinition ifCompatibleStatement whileLoop forLoop factor2 factor3 lValue
-%type<nodeList> instanceStatementList localStatementList parameterList argumentList
+%type<node> expression instanceStatement localStatement compoundStatement functionDefinition functionPrototype parameter returnStatement functionCall arithmeticExpression term factor closedStatement openStatement booleanExpression booleanExpression2 booleanExpression3 variableDeclaration variableAssignment variableDefinition ifCompatibleStatement whileLoop forLoop factor2 factor3 factor4 arrayInitList
+%type<nodeList> instanceStatementList localStatementList parameterList parameterList2 argumentList argumentList2
 
 %start program
 
@@ -53,7 +53,7 @@ instanceStatementList
     ;
 
 instanceStatement
-    : functionDefinition {$$ = $1;}
+    : functionDefinition
     ;
 
 localStatementList
@@ -62,15 +62,15 @@ localStatementList
     ;
 
 localStatement
-    : ifCompatibleStatement {$$ = $1;}
-    | variableDeclaration TOK_SEMICOLON
-    | variableDefinition TOK_SEMICOLON
+    : ifCompatibleStatement
+    | variableDeclaration TOK_SEMICOLON {$$ = $1;}
+    | variableDefinition TOK_SEMICOLON {$$ = $1;}
     ;
 
 /* this defines statements that are safe to use inside of if-statements with the ':' syntax */
 ifCompatibleStatement
-    : closedStatement {$$ = $1;}
-    | openStatement {$$ = $1;}
+    : closedStatement
+    | openStatement
     ;
 
 /* this defines statements that are self closing and cannot be interpreted as the start of a bigger statement */
@@ -79,9 +79,9 @@ closedStatement
     | TOK_IF expression TOK_COLON closedStatement TOK_ELSE closedStatement {$$ = new ASTIfElseStatement($2, $4, $6);}
     | expression TOK_SEMICOLON {$$ = $1;}
     | returnStatement TOK_SEMICOLON {$$ = $1;}
-    | whileLoop {$$ = $1;}
-    | forLoop {$$ = $1;}
-    | compoundStatement {$$ = $1;}
+    | whileLoop
+    | forLoop
+    | compoundStatement
     | TOK_CONTINUE TOK_SEMICOLON {$$ = new ASTContinueStatement();}
     | TOK_BREAK TOK_SEMICOLON {$$ = new ASTBreakStatement();}
     ;
@@ -105,19 +105,19 @@ variableDeclaration
     ;
 
 variableAssignment
-    : lValue TOK_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "");}
-    | lValue TOK_PLUS_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "+");}
-    | lValue TOK_HYPHEN_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "-");}
-    | lValue TOK_ASTERISK_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "*");}
-    | lValue TOK_F_SLASH_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "/");}
-    | lValue TOK_PERCENT_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "%");}
+    : booleanExpression TOK_EQUALS expression {$$ = new ASTVariableAssignment($1, $3);}
+    | booleanExpression TOK_PLUS_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "+");}
+    | booleanExpression TOK_HYPHEN_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "-");}
+    | booleanExpression TOK_ASTERISK_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "*");}
+    | booleanExpression TOK_F_SLASH_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "/");}
+    | booleanExpression TOK_PERCENT_EQUALS expression {$$ = new ASTVariableAssignment($1, $3, "%");}
     ;
 
 variableDefinition
     : TOK_IDENTIFIER TOK_COLON TOK_TYPE TOK_EQUALS expression {$$ = new ASTVariableDefinition($1->getString(), $3->getString(), $5); delete $1; delete $3;}
-    | TOK_IDENTIFIER TOK_COLON TOK_EQUALS expression {$$ = new ASTVariableDefinition($1->getString(), "auto", $4); delete $1;}
+    | TOK_IDENTIFIER TOK_WALRUS expression {$$ = new ASTVariableDefinition($1->getString(), "auto", $3); delete $1;}
     | TOK_MUT TOK_IDENTIFIER TOK_COLON TOK_TYPE TOK_EQUALS expression {$$ = new ASTVariableDefinition($2->getString(), $4->getString(), $6, true); delete $2; delete $4;}
-    | TOK_MUT TOK_IDENTIFIER TOK_COLON TOK_EQUALS expression {$$ = new ASTVariableDefinition($2->getString(), "auto", $5, true); delete $2;}
+    | TOK_MUT TOK_IDENTIFIER TOK_WALRUS expression {$$ = new ASTVariableDefinition($2->getString(), "auto", $4, true); delete $2;}
     ;
 
 functionDefinition
@@ -125,7 +125,7 @@ functionDefinition
     ;
 
 functionPrototype
-    : TOK_FN TOK_IDENTIFIER TOK_L_PAREN parameterList TOK_R_PAREN {$$ = new ASTFunctionPrototype($2->getString(), $4->getVector(), ""); delete $2; delete $4;}
+    : TOK_FN TOK_IDENTIFIER TOK_L_PAREN parameterList TOK_R_PAREN {$$ = new ASTFunctionPrototype($2->getString(), $4->getVector()); delete $2; delete $4;}
     | TOK_FN TOK_IDENTIFIER TOK_L_PAREN parameterList TOK_R_PAREN TOK_ARROW TOK_TYPE {$$ = new ASTFunctionPrototype($2->getString(), $4->getVector(), $7->getString()); delete $2; delete $4; delete $7;}
     ;
 
@@ -143,9 +143,13 @@ returnStatement
     ;
 
 parameterList
-    : parameterList TOK_COMMA parameter {$$ = $1; $$->push($3);}
-    | parameter {$$ = new VectorWrapper($1);}
+    : parameterList2
     | {$$ = new VectorWrapper();}
+    ;
+
+parameterList2
+    : parameterList2 TOK_COMMA parameter {$$ = $1; $$->push($3);}
+    | parameter {$$ = new VectorWrapper($1);}
     ;
 
 parameter
@@ -157,25 +161,34 @@ functionCall
     : TOK_IDENTIFIER TOK_L_PAREN argumentList TOK_R_PAREN {$$ = new ASTFunctionCall($1->getString(), $3->getVector()); delete $1; delete $3;}
     ;
 
+arrayInitList
+    : TOK_L_BRACKET argumentList TOK_R_BRACKET {$$ = new ASTArrayInitList($2->getVector()); delete $2;}
+    | TOK_TYPE TOK_L_BRACKET argumentList TOK_R_BRACKET {$$ = new ASTArrayInitList($3->getVector(), $1->getString()); delete $1; delete $3;}
+    ;
+
 argumentList
-    : argumentList TOK_COMMA expression {$$ = $1; $$->push($3);}
-    | expression {$$ = new VectorWrapper($1);}
+    : argumentList2
     | {$$ = new VectorWrapper();}
     ;
 
+argumentList2
+    : argumentList2 TOK_COMMA expression {$$ = $1; $$->push($3);}
+    | expression {$$ = new VectorWrapper($1);}
+    ;
+
 expression
-    : booleanExpression {$$ = $1;}
-    | variableAssignment {$$ = $1;}
+    : booleanExpression
+    | variableAssignment
     ;
 
 booleanExpression
     : booleanExpression TOK_OR booleanExpression2 {$$ = new ASTBinaryOperator($1, $3, "||");}
-    | booleanExpression2 {$$ = $1;}
+    | booleanExpression2
     ;
 
 booleanExpression2
     : booleanExpression2 TOK_AND booleanExpression3 {$$ = new ASTBinaryOperator($1, $3, "&&");}
-    | booleanExpression3 {$$ = $1;}
+    | booleanExpression3
     ;
 
 booleanExpression3
@@ -186,66 +199,68 @@ booleanExpression3
     | arithmeticExpression TOK_GREATER_THAN arithmeticExpression {$$ = new ASTBinaryOperator($1, $3, ">");}
     | arithmeticExpression TOK_LESS_THAN_EQUALS arithmeticExpression {$$ = new ASTBinaryOperator($1, $3, "<=");}
     | arithmeticExpression TOK_GREATER_THAN_EQUALS arithmeticExpression {$$ = new ASTBinaryOperator($1, $3, ">=");}
-    | arithmeticExpression {$$ = $1;}
+    | arithmeticExpression
     ;
 
 arithmeticExpression
     : arithmeticExpression TOK_PLUS term {$$ = new ASTBinaryOperator($1, $3, "+");}
     | arithmeticExpression TOK_HYPHEN term {$$ = new ASTBinaryOperator($1, $3, "-");}
-    | term {$$ = $1;}
+    | term
     ;
 
 term
     : term TOK_ASTERISK factor {$$ = new ASTBinaryOperator($1, $3, "*");}
     | term TOK_F_SLASH factor {$$ = new ASTBinaryOperator($1, $3, "/");}
     | term TOK_PERCENT factor {$$ = new ASTBinaryOperator($1, $3, "%");}
-    | factor {$$ = $1;}
+    | factor
     ;
 
 factor
     : TOK_HYPHEN factor {$$ = new ASTUnaryOperator($2, "-");} /* To handle cases like: (-5) * 2; and 3 * -2; */
     | TOK_PLUS factor {$$ = new ASTUnaryOperator($2, "+");}
-    | factor2 {$$ = $1;}
+    | factor2
     ;
 
 factor2
     : factor2 TOK_AS TOK_TYPE {$$ = new ASTTypeCast($1, $3->getString()); delete $3;}
     | factor2 TOK_TILDA TOK_TYPE {$$ = new ASTTypeCast($1, $3->getString()); delete $3;}
-    | factor3 {$$ = $1;}
+    | factor3
     ;
 
 factor3
+    : TOK_ASTERISK factor3 {$$ = new ASTDereferenceOperator($2);}
+    | factor4
+    ;
+
+factor4
     : TOK_INT_LITERAL {$$ = new ASTInteger($1);}
     | TOK_FLOAT_LITERAL {$$ = new ASTFloat($1);}
     | TOK_STR_LITERAL {$$ = new ASTString($1->getString()); delete $1;}
     | TOK_CHAR_LITERAL {$$ = new ASTChar($1);}
     | TOK_TRUE {$$ = new ASTBool(true);}
     | TOK_FALSE {$$ = new ASTBool(false);}
-    | functionCall {$$ = $1;}
+    | functionCall
+    | arrayInitList
     | TOK_IDENTIFIER TOK_INCREMENT {$$ = new ASTIncrementDecrementOperator($1->getString(), "x++"); delete $1;}
     | TOK_IDENTIFIER TOK_DECREMENT {$$ = new ASTIncrementDecrementOperator($1->getString(), "x--"); delete $1;}
     | TOK_INCREMENT TOK_IDENTIFIER {$$ = new ASTIncrementDecrementOperator($2->getString(), "++x"); delete $2;}
     | TOK_DECREMENT TOK_IDENTIFIER {$$ = new ASTIncrementDecrementOperator($2->getString(), "--x"); delete $2;}
     | TOK_AMPERSAND TOK_IDENTIFIER {$$ = new ASTAddressOfOperator($2->getString(), false); delete $2;}
     | TOK_AMPERSAND TOK_MUT TOK_IDENTIFIER {$$ = new ASTAddressOfOperator($3->getString(), true); delete $3;}
-    | TOK_L_PAREN expression TOK_R_PAREN {$$ = $2;}
-    | lValue {$$ = $1;}
-    ;
-
-lValue
-    : TOK_ASTERISK factor3 {$$ = new ASTDereferenceOperator($2);}
+    | factor4 TOK_L_BRACKET expression TOK_R_BRACKET {$$ = new ASTArrayIndex($1, $3);}
     | TOK_IDENTIFIER {$$ = new ASTVariableExpression($1->getString()); delete $1;}
+    | TOK_L_PAREN expression TOK_R_PAREN {$$ = $2;}
     ;
 %%
 
 // runs when bison finds an error
-void yyerror(const char *s) {
+void yyerror(const char* s) {
     parser::fatal_error(std::chrono::high_resolution_clock::now(), s, "A parsing error occurred on line: " + std::to_string(yylineno));
 }
 
 // the function to call to run the bison grammar
 std::unique_ptr<AST> &parse(const std::string& filename) {
-    FILE *file = fopen(filename.c_str(), "r");
+    FILE* file = fopen(filename.c_str(), "r");
     // yyin is the file that bison will read from
     yyin = file;
 

--- a/src/parser/wrappers.h
+++ b/src/parser/wrappers.h
@@ -11,54 +11,44 @@
 // create a wrapper struct around the std::vector,
 // so that it can be used in the bison union
 struct VectorWrapper {
-    std::vector<ASTNode*>* vector;
+ private:
+    std::vector<ASTNode*> vector;
 
+ public:
     // construct empty vector
-    VectorWrapper() { vector = new std::vector<ASTNode*>(); }
+    VectorWrapper() = default;
 
     // construct vector with one node
-    explicit VectorWrapper(ASTNode* firstNode) {
-        vector = new std::vector<ASTNode*>();
-        vector->push_back(firstNode);
+    explicit VectorWrapper(ASTNode* firstNode) : vector({firstNode}) {}
+
+    void push(ASTNode* node) { vector.push_back(node); }
+
+    [[nodiscard]] const std::vector<ASTNode*>& getVector() const {
+        return vector;
     }
-
-    ~VectorWrapper() { delete vector; }
-
-    void push(ASTNode* node) const { vector->push_back(node); }
-
-    [[nodiscard]] std::vector<ASTNode*>& getVector() const { return *vector; }
 };
-
-static std::string* replaceEscape(const std::string& string) {
-    // replace all "\\n" with "\n"
-    std::string modifiedString =
-        std::regex_replace(string, std::regex("\\\\n"), "\n");
-    // replace all "\\t" with "\t"
-    modifiedString =
-        std::regex_replace(modifiedString, std::regex("\\\\t"), "\t");
-    return new std::string(std::move(modifiedString));
-}
 
 // create a wrapper struct around the std::string,
 // so that it can be used in the bison union
 struct StringWrapper {
-    std::string* string;
+ private:
+    std::string string;
 
-    // create a std::string from s and store it in string
-    explicit StringWrapper(char* s) {
-        std::string str(s);
-        // to replace \\n, \\t and so on with just one \ so it works correctly
-        string = replaceEscape(str);
+    void replaceEscape() {
+        // replace all "\\n" with "\n"
+        string = std::regex_replace(string, std::regex("\\\\n"), "\n");
+        // replace all "\\t" with "\t"
+        string = std::regex_replace(string, std::regex("\\\\t"), "\t");
     }
+
+ public:
+    // create a std::string from s and store it in string
+    explicit StringWrapper(const char* s) : string(s) { replaceEscape(); }
 
     // create a std::string from s and length and store it in string
-    explicit StringWrapper(char* s, int length) {
-        std::string str(s, length);
-        // to replace \\n, \\t and so on with just one \ so it works correctly
-        string = replaceEscape(str);
+    explicit StringWrapper(const char* s, size_t length) : string(s, length) {
+        replaceEscape();
     }
 
-    ~StringWrapper() { delete string; }
-
-    [[nodiscard]] std::string& getString() const { return *string; }
+    [[nodiscard]] const std::string& getString() const { return string; }
 };

--- a/tests/code.lts
+++ b/tests/code.lts
@@ -1,27 +1,27 @@
-fn foo(mut x: i32, y: f64) {
-    x = 86;
-    // y = 5.34; -> gives error
-    printf("x: %d, y: %f\n", x, y);
+fn plotBooleanGrid(arr1: [bool|5], arr2: [bool|5]) {
+    for mut i := 0; i < 5; i++ {
+        for mut j := 0; j < 5; j++ {
+            if arr1[i] && arr2[j] {
+                printf("# ");
+            } else if !arr1[i] && !arr2[j] {
+                printf("  ");
+            } else {
+                printf("* ");
+            }
+        }
+        printf("\n");
+    }
 }
 
 fn main() {
-    x: i32 = 10;
-    // x = 5; -> gives error
-
-    mut y: i32 = 45;
-    y = 5;
-
-    a: *i32 = &x;
-    // *a = 5; -> gives error
-
-    b: *mut i32 = &mut y;
-    *b = 34;
-
-    printf("%d, %d\n", x, y);
-
-    foo(123, 345.4);
+    arr1: [bool|5] = bool[1, 0, 1, 1, 0];
+    arr2: [bool|5] = bool[0, 1, 0, 1, 1];
+    plotBooleanGrid(arr1, arr2);
 }
 
 // output:
-// 10, 34
-// x: 86, y: 345.400000
+// * # * # #
+//   *   * *
+// * # * # #
+// * # * # #
+//   *   * *

--- a/tests/code/arrays.lts
+++ b/tests/code/arrays.lts
@@ -1,0 +1,74 @@
+fn modifyArray(array: *mut [i32|10], index: i8, newValue: i32) {
+    (*array)[index] = newValue;
+}
+
+fn printArrayI32(array: [i32|10]) {
+    printf("[");
+    for mut i := 0; i < 10; i++ {
+        if i < 9: printf("%d, ", array[i]);
+        else printf("%d]\n", array[i]);
+    }
+}
+
+fn castArrayToF64(array: [i32|10]) -> [f64|10] {
+    mut newArray: [f64|10];
+    for mut i := 0; i < 10; i++ {
+        newArray[i] = array[i] as f64;
+    }
+    ret newArray;
+}
+
+fn printArrayF64(array: [f64|10]) {
+    printf("[");
+    for mut i := 0; i < 10; i++ {
+        if i < 9: printf("%f, ", array[i]);
+        else printf("%f]\n", array[i]);
+    }
+}
+
+fn testAssignmentsAsLValues() {
+    mut x: [i32|10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+    mut y: [i32|10];
+    (y = x)[5] = 100;
+    printf("x: %d\n", x[5]);
+
+    mut a := 10;
+    mut b: i32;
+    (b = a) = 15;
+    printf("a: %d, b: %d\n", a, b);
+}
+
+fn main() {
+    mut x := [2, 3, 4, 5, 23, 4, 56, 7, 3, 2];
+    printArrayI32(x);
+    modifyArray(&mut x, 4~i8, 100);
+    printArrayI32(x);
+
+    y: [f64|10] = castArrayToF64(x);
+    printArrayF64(y);
+
+    mut z: [i32|10] = i32[1, 2, 3, 4, 5, 6.7, 'a', 9, 2, -3];
+    z[6] = 42;
+    for mut i := 0; i < 10; i++ {
+        printf("Array at %d: %d\n", i, z[i]);
+    }
+
+    testAssignmentsAsLValues();
+}
+
+// output:
+// [2, 3, 4, 5, 23, 4, 56, 7, 3, 2]
+// [2, 3, 4, 5, 100, 4, 56, 7, 3, 2]
+// [2.000000, 3.000000, 4.000000, 5.000000, 100.000000, 4.000000, 56.000000, 7.000000, 3.000000, 2.000000]
+// Array at 0: 1
+// Array at 1: 2
+// Array at 2: 3
+// Array at 3: 4
+// Array at 4: 5
+// Array at 5: 6
+// Array at 6: 42
+// Array at 7: 9
+// Array at 8: 2
+// Array at 9: -3
+// x: 100
+// a: 15, b: 10

--- a/tests/code/break_and_continue.lts
+++ b/tests/code/break_and_continue.lts
@@ -14,31 +14,31 @@ fn main() {
         }
         i += 1;
     }
-
-    // Output:
-    // i: 0, j: 0
-    // i: 0, j: 1
-    // i: 0, j: 2
-    // continue, i: 0, j: 3
-    // i: 0, j: 4
-    // i: 1, j: 0
-    // i: 1, j: 1
-    // i: 1, j: 2
-    // continue, i: 1, j: 3
-    // i: 1, j: 4
-    // i: 2, j: 0
-    // i: 2, j: 1
-    // i: 2, j: 2
-    // continue, i: 2, j: 3
-    // break, i: 2, j: 4
-    // i: 3, j: 0
-    // i: 3, j: 1
-    // i: 3, j: 2
-    // continue, i: 3, j: 3
-    // i: 3, j: 4
-    // i: 4, j: 0
-    // i: 4, j: 1
-    // i: 4, j: 2
-    // continue, i: 4, j: 3
-    // i: 4, j: 4
 }
+
+// output:
+// i: 0, j: 0
+// i: 0, j: 1
+// i: 0, j: 2
+// continue, i: 0, j: 3
+// i: 0, j: 4
+// i: 1, j: 0
+// i: 1, j: 1
+// i: 1, j: 2
+// continue, i: 1, j: 3
+// i: 1, j: 4
+// i: 2, j: 0
+// i: 2, j: 1
+// i: 2, j: 2
+// continue, i: 2, j: 3
+// break, i: 2, j: 4
+// i: 3, j: 0
+// i: 3, j: 1
+// i: 3, j: 2
+// continue, i: 3, j: 3
+// i: 3, j: 4
+// i: 4, j: 0
+// i: 4, j: 1
+// i: 4, j: 2
+// continue, i: 4, j: 3
+// i: 4, j: 4


### PR DESCRIPTION
Added array types (like for example: [i32|10]), and array initialization lists (array literals) with the ability to cast all elements to a specific type when constructing the array (like for example: f64[1, 2, 3]). I also added an error when the main function is not present, and created a separate token for the walrus operator ":=" instead of just using two tokens for ":" and "=" in the parser. I also fixed a parsing issue where an extra comma would be allowed in argument and parameter lists (like for example: foo(, 1, 2, 3)).